### PR TITLE
removed duplicated form field (always present)

### DIFF
--- a/src/views/dashboard/variant-edit.php
+++ b/src/views/dashboard/variant-edit.php
@@ -105,9 +105,6 @@ use yii\widgets\ActiveForm;
             }
             echo $stockField;
         }
-        if (ShopSettings::shopProductAllowConfigurableVariant()) {
-            echo $form->field($model, 'configurator_url');
-        }
         echo Html::errorSummary($model);
 
         echo Html::submitButton(Yii::t('shop', '{icon} Save', ['icon' => FA::icon(FA::_SAVE)]), ['class' => 'btn btn-primary']);

--- a/src/views/dashboard/variant-edit.php
+++ b/src/views/dashboard/variant-edit.php
@@ -61,13 +61,7 @@ use yii\widgets\ActiveForm;
                 'theme' => Select2::THEME_BOOTSTRAP
             ]
         ]);
-        echo $form->field($model, 'configurator_bg_image')->widget(FileManagerInputWidget::class, [
-            'handlerUrl' => '/filefly/api',
-            'select2Options' => [
-                'theme' => Select2::THEME_BOOTSTRAP
-            ]
-        ]);
-        echo $form->field($model, 'configurator_url');
+
         echo $form->field($model, 'price')->widget(NumberControl::class, ['maskedInputOptions' => [
             'suffix' => ' ' . $this->context->module->currency,
             'groupSeparator' => '.',
@@ -104,6 +98,16 @@ use yii\widgets\ActiveForm;
                 $stockField->hint(Yii::t('shop', 'There are less than {count} in stock', ['count' => ShopSettings::shopProductFewAvailableWarning()]), ['class' => 'text-warning']);
             }
             echo $stockField;
+        }
+        if (ShopSettings::shopProductAllowConfigurableVariant()) {
+            echo $form->field($model, 'configurator_url');
+
+            echo $form->field($model, 'configurator_bg_image')->widget(FileManagerInputWidget::class, [
+                'handlerUrl' => '/filefly/api',
+                'select2Options' => [
+                    'theme' => Select2::THEME_BOOTSTRAP
+                ]
+            ]);
         }
         echo Html::errorSummary($model);
 


### PR DESCRIPTION
@eluhr After the last features PRs the field 'configurator_url appears two times in the varian-edit form. I removed the one field in the if statement so it can be configured also when it'S not yet active.  Would like o have your opinion on this and make the necessary changes to marge this.