### PR TITLE
changed dompdf/dompdf contraints due to security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "kartik-v/yii2-number": "^1.0",
         "eluhr/yii2-sortablejs": "^0.0.5",
         "kartik-v/yii2-export": "^1.4",
-        "dompdf/dompdf": "^1.2.1",
+        "dompdf/dompdf": "^2.0.3",
         "dmstr/yii2-helpers": "^0.4.18"
     },
     "suggest": {


### PR DESCRIPTION
dompdf/dompdf constraint was `^1.2.1`, but pkg must be upgraded to >= 2.0.3
see: https://packagist.org/packages/dompdf/dompdf/advisories

I've not testet the pdf generation (yet) but as far as i see, 'only' a simple pdf are generated.

@eluhr can you check if newer dompdf works as expected?