### PR TITLE
product filter

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -18,7 +18,7 @@ class DefaultController extends Controller
 
         $this->view->title = \Yii::t('shop', '__SHOP_OVERVIEW_TITLE__');
 
-        $query = Product::find()->moreThanOneVariantActive()->isVisible()->active()->orderByRank();
+        $query = Product::find()->online()->orderByRank();
 
         if ($filterForm->load(\Yii::$app->request->get())) {
             $query->hasTagsAssigned($filterForm->tagIds());

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -5,30 +5,29 @@ namespace eluhr\shop\controllers;
 
 use eluhr\shop\models\Filter;
 use eluhr\shop\models\form\Filter as FilterForm;
-use eluhr\shop\models\Product;
-use yii\data\ActiveDataProvider;
+use eluhr\shop\models\search\ProductFinder;
 
 class DefaultController extends Controller
 {
     public function actionIndex()
     {
         $filters = Filter::find()->orderByRank()->active()->all();
-
         $filterForm = new FilterForm();
 
         $this->view->title = \Yii::t('shop', '__SHOP_OVERVIEW_TITLE__');
 
-        $query = Product::find()->online()->orderByRank();
-
-        if ($filterForm->load(\Yii::$app->request->get())) {
-            $query->hasTagsAssigned($filterForm->tagIds());
-            $query->fullTextSearch($filterForm->q);
+        $filterParams = [];
+        if ($filterForm->load(\Yii::$app->request->get()) && $filterForm->validate()) {
+            $filterParams = [
+                'tagIds' => $filterForm->tagIds(),
+                'q' => $filterForm->q
+            ];
         }
 
+        $finder = new ProductFinder();
         return $this->render('index', [
-            'dataProvider' => new ActiveDataProvider([
-                'query' => $query
-            ]),
+            'finder' => $finder,
+            'dataProvider' => $finder->search($filterParams),
             'filters' => $filters,
             'filterForm' => $filterForm,
         ]);

--- a/src/models/form/Filter.php
+++ b/src/models/form/Filter.php
@@ -51,7 +51,9 @@ class Filter extends Model
         foreach ($this->tag as $tags) {
             if (is_array($tags)) {
                 foreach ($tags as $tag) {
-                    $tagIds[] = $tag;
+                    if (!empty($tag)) {
+                        $tagIds[] = $tag;
+                    }
                 }
             }
         }

--- a/src/models/query/ProductQuery.php
+++ b/src/models/query/ProductQuery.php
@@ -37,6 +37,24 @@ class ProductQuery extends \yii\db\ActiveQuery
         return $this->andWhere([$prefix . 'hide_in_overview' => 0]);
     }
 
+    /**
+     * shorthand for $this->moreThanOneVariantActive()->isVisible()->active()
+     * useful to get query for products that:
+     * - are visible and active
+     * - and have min. one active variant
+     *
+     * @return ProductQuery
+     */
+    public function online()
+    {
+        return $this->moreThanOneVariantActive()->isVisible()->active();
+    }
+
+    /**
+     * get query for products with min. one active variant
+     *
+     * @return ProductQuery
+     */
     public function moreThanOneVariantActive()
     {
         $query =

--- a/src/models/query/ProductQuery.php
+++ b/src/models/query/ProductQuery.php
@@ -59,7 +59,8 @@ class ProductQuery extends \yii\db\ActiveQuery
     {
         $query =
             $this->alias(self::ALIAS)
-                ->select(self::ALIAS . '.*')
+                // always set p.* or p.id as first col as we need to be able to run query with column() which returns the "first" col in result-set
+                ->select([self::ALIAS . '.*'])
                 ->leftJoin(
                     [
                         VariantQuery::ALIAS => Variant::tableName()

--- a/src/models/search/ProductFinder.php
+++ b/src/models/search/ProductFinder.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace eluhr\shop\models\search;
+
+use Yii;
+use yii\base\Model;
+use yii\data\ActiveDataProvider;
+use eluhr\shop\models\Product as ProductModel;
+use yii\helpers\VarDumper;
+
+/**
+ * ProductFinder provides the search() Method for`eluhr\shop\models\Product`.
+ */
+class ProductFinder extends Model
+{
+    public $tagIds;
+    public $q;
+
+    public $defaultOrder = ['rank' => SORT_ASC];
+
+    /**
+     * we need query as property to be able to access it in other Methods of this instance
+     * @var \yii\db\ActiveQuery
+     */
+    protected $query;
+
+    /**
+     * internal cache Var for self::getAllModelIds
+     *
+     * @var false|array
+     */
+    protected $_allModelIds = false;
+
+    protected $_availableModelIds = false;
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return [
+            [['tagIds'], 'integer', 'allowArray' => true],
+            [['q'], 'string'],
+        ];
+    }
+
+    public function formName()
+    {
+        return '';
+    }
+
+    /**
+     * Creates data provider instance with search query applied
+     *
+     * @param array $params
+     *
+     * @return ActiveDataProvider
+     */
+    public function search($params)
+    {
+        $this->query = $this->getBaseQuery();
+
+        $dataProvider = new ActiveDataProvider([
+            'query' => $this->query,
+        ]);
+        $sort = $dataProvider->getSort();
+        $sort->defaultOrder = $this->defaultOrder;
+
+        $this->load($params);
+
+        if (!$this->validate()) {
+            // uncomment the following line if you do not want to any records when validation fails
+            // $this->query->where('0=1');
+            return $dataProvider;
+        }
+
+        if (!empty($this->tagIds)) {
+            $this->query->hasTagsAssigned($this->tagIds);
+        }
+
+        if (!empty($this->q)) {
+            $this->query->fullTextSearch($this->q);
+        }
+
+        return $dataProvider;
+    }
+
+
+    protected function getBaseQuery()
+    {
+        return ProductModel::find()->online();
+    }
+
+    /**
+     * get all Product Model IDs that are 'online' without filtering
+     *
+     * @return array
+     */
+    public function getAvailableModelIds()
+    {
+        if ($this->_availableModelIds === false) {
+            $this->_availableModelIds = $this->getBaseQuery()->column();
+        }
+        return $this->_availableModelIds;
+    }
+
+    /**
+     * get all ModelIds in the current finder context, which are allModels of this dataProvider()
+     *
+     * @return array|false
+     */
+    public function getAllModelIds()
+    {
+        if ($this->_allModelIds === false) {
+            $query = clone $this->query;
+            $query->limit(-1)->offset(-1)->asArray();
+            $this->_allModelIds = $query->column();
+
+        }
+        return $this->_allModelIds;
+    }
+}

--- a/src/views/default/_filter.php
+++ b/src/views/default/_filter.php
@@ -1,9 +1,9 @@
 <?php
 
-use eluhr\shop\models\ShopSettings;
-use kartik\select2\Select2;
 use eluhr\shop\models\Filter;
 use eluhr\shop\models\form\Filter as FilterForm;
+use eluhr\shop\models\ShopSettings;
+use kartik\select2\Select2;
 use rmrevin\yii\fontawesome\FA;
 use yii\helpers\Html;
 use yii\widgets\ActiveForm;
@@ -11,6 +11,7 @@ use yii\widgets\ActiveForm;
 /**
  * @var $filters Filter[]
  * @var $filterForm FilterForm
+ * @var \eluhr\shop\models\search\ProductFinder $finder
  */
 ?>
 <div class="filters">
@@ -23,7 +24,8 @@ use yii\widgets\ActiveForm;
         }
 
         foreach ($filters as $filter) {
-            $data = $filter->tagData();
+            // if we want to make filters more strict, $finder->
+            $data = $filter->tagFacets($finder->getAvailableModelIds());
             if (!empty($data)) {
                 $field = $form->field($filterForm, 'tag[' . $filter->id . '][]', ['options' => ['class' => 'filter']]);
                 if ($filter->presentation === Filter::PRESENTATION_DROPDOWN) {

--- a/src/views/default/_filter.php
+++ b/src/views/default/_filter.php
@@ -24,7 +24,7 @@ use yii\widgets\ActiveForm;
         }
 
         foreach ($filters as $filter) {
-            // if we want to make filters more strict, $finder->
+            // if we want to make filters more strict, use $finder->getAllModelIds() here
             $data = $filter->tagFacets($finder->getAvailableModelIds());
             if (!empty($data)) {
                 $field = $form->field($filterForm, 'tag[' . $filter->id . '][]', ['options' => ['class' => 'filter']]);

--- a/src/views/default/index.php
+++ b/src/views/default/index.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * @var \eluhr\shop\models\search\ProductFinder $finder
  * @var ActiveDataProvider $dataProvider
  * @var View $this
  * @var Filter[] $filters
@@ -14,13 +15,15 @@ use yii\data\ActiveDataProvider;
 use yii\web\View;
 use yii\widgets\ListView;
 
+Yii::debug($dataProvider->sort);
+
 ?>
 
 <?= Cell::widget(['id' => 'shop-top-global'])?>
 <div class="items-view">
     <?php
     if (ShopSettings::shopGeneralShowFilters()) {
-        echo $this->render('_filter', ['filters' => $filters, 'filterForm' => $filterForm]);
+        echo $this->render('_filter', ['filters' => $filters, 'filterForm' => $filterForm, 'finder' => $finder]);
     }
     ?>
 


### PR DESCRIPTION
Currently all tags related to a filter (without any check to products) are displayed as filter opts

This can/will easily lead to empty results.

This PR refactor the way products are selected on the overview page and which filter options are displayed.
In Addition, a few glitches while creating the product queries have been fixed.

- The [ProductQuery::online() shortcut](https://github.com/eluhr/yii2-shop-module/commit/ce3595b4946876059c74f3c75242097f96d72d01) encapsulate the chained method calls that are required to get "online" Products.
- To get the Products we now have a ProductFinder search model instead of a plain ActiveDataProvider with product Query.
- In the ProductQuery, only the required joins, having() calls, etc. are performed depending on the specified parameters.
