### PR TITLE
allow overload model classes returned by ActiveQuery via DI

### DIFF
--- a/src/models/ActiveRecord.php
+++ b/src/models/ActiveRecord.php
@@ -22,4 +22,20 @@ class ActiveRecord extends BaseActiveRecord
         ];
         return $behaviors;
     }
+
+    /**
+     * overwrite \yii\db\BaseActiveRecord::instantiate() to be able to overload model classes returned by ActiveQuery
+     *
+     * The default implementation return new static() models, but Yii::createObject()
+     * must be used to be able to overload model classes via DI
+     *
+     * @param array $row
+     *
+     * @return ActiveRecord|object
+     * @throws \yii\base\InvalidConfigException
+     */
+    public static function instantiate($row)
+    {
+        return \Yii::createObject(static::class);
+    }
 }


### PR DESCRIPTION
This PR overwrite ActiveRecord::instantiate() to be able to overload model classes returned by ActiveQuery via DI