### PR TITLE
add checkbox as valid presentation type for filters & cleanup

### DIFF
--- a/src/migrations/m230428_100000_add_checkbox_opt_2_filter.php
+++ b/src/migrations/m230428_100000_add_checkbox_opt_2_filter.php
@@ -1,0 +1,22 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m230428_100000_add_checkbox_opt_2_filter
+ *
+ * this migration adds the checkbox option to the filter.presentation enum
+ *
+ */
+class m230428_100000_add_checkbox_opt_2_filter extends Migration
+{
+    public function up()
+    {
+        $this->alterColumn('sp_filter', 'presentation', 'ENUM("dropdown", "radios", "checkbox") NOT NULL DEFAULT "dropdown"');
+    }
+
+    public function down()
+    {
+        $this->alterColumn('sp_filter', 'presentation', 'ENUM("dropdown", "radios") NOT NULL DEFAULT "dropdown"');
+    }
+}

--- a/src/models/Filter.php
+++ b/src/models/Filter.php
@@ -36,15 +36,6 @@ class Filter extends BaseFilter
         return $rules;
     }
 
-
-    public static function presentations()
-    {
-        return [
-            self::PRESENTATION_DROPDOWN => Yii::t('shop', 'Dropdown'),
-            self::PRESENTATION_RADIOS => Yii::t('shop', 'Radios'),
-        ];
-    }
-
     public function tagData()
     {
         return ArrayHelper::map($this->getTagXFilters()->orderBy(['rank' => SORT_ASC])->all(), 'tag.id', 'tag.name');

--- a/src/models/base/Filter.php
+++ b/src/models/base/Filter.php
@@ -31,6 +31,8 @@ abstract class Filter extends \eluhr\shop\models\ActiveRecord
     */
     const PRESENTATION_DROPDOWN = 'dropdown';
     const PRESENTATION_RADIOS = 'radios';
+    const PRESENTATION_CHECKBOX = 'checkbox';
+
     /**
      * @inheritdoc
      */
@@ -54,6 +56,7 @@ abstract class Filter extends \eluhr\shop\models\ActiveRecord
             ['presentation', 'in', 'range' => [
                     self::PRESENTATION_DROPDOWN,
                     self::PRESENTATION_RADIOS,
+                    self::PRESENTATION_CHECKBOX,
                 ]
             ]
         ];
@@ -125,6 +128,7 @@ abstract class Filter extends \eluhr\shop\models\ActiveRecord
         return [
             self::PRESENTATION_DROPDOWN => Yii::t('shop', 'Dropdown'),
             self::PRESENTATION_RADIOS => Yii::t('shop', 'Radios'),
+            self::PRESENTATION_CHECKBOX => Yii::t('shop', 'Checkboxes'),
         ];
     }
 

--- a/src/views/dashboard/filters/edit.php
+++ b/src/views/dashboard/filters/edit.php
@@ -28,7 +28,7 @@ use yii\widgets\ActiveForm;
         if ($model->isNewRecord) {
             $model->presentation = $model::PRESENTATION_DROPDOWN;
         }
-        echo $form->field($model, 'presentation')->radioList(Filter::presentations());
+        echo $form->field($model, 'presentation')->radioList(Filter::optsPresentation());
         echo $form->field($model, 'is_online')->checkbox([], false);
         echo $form->field($model, 'rank');
         echo $form->field($model, 'filterIds')->widget(Select2::class, [

--- a/src/views/default/_filter.php
+++ b/src/views/default/_filter.php
@@ -42,6 +42,13 @@ use yii\widgets\ActiveForm;
                             'class' => 'filter-collapse'
                         ]
                     ]);
+                } elseif ($filter->presentation === Filter::PRESENTATION_CHECKBOX) {
+                    $field->checkboxList($data, [
+                        'itemOptions' => [
+                            'data-filter' => 'filter-form'
+                        ],
+                        'class' => 'filter-collapse'
+                    ]);
                 } else {
                     $field->radioList($data, [
                         'itemOptions' => [


### PR DESCRIPTION
This PR:
- add migration for new enum value in filter table
- add filter PRESENTATION const for checkbox
- add checkbox condition in _filter view
- remove duplicate code: models\Filter::presentation() was duplicate of models\base\Filter::optsPresentation()