### PR TITLE
ProductFinder: add (optional) productId filter

### DIFF
--- a/src/models/query/ProductQuery.php
+++ b/src/models/query/ProductQuery.php
@@ -37,6 +37,16 @@ class ProductQuery extends \yii\db\ActiveQuery
         return $this->andWhere([$prefix . 'hide_in_overview' => 0]);
     }
 
+    public function productIdFilter($id)
+    {
+        $prefix = '';
+        if (isset($this->getTableNameAndAlias()[1]) && $this->getTableNameAndAlias()[1] === self::ALIAS) {
+            $prefix = self::ALIAS . '.';
+        }
+
+        return $this->andWhere([$prefix . 'id' => $id]);
+    }
+
     /**
      * shorthand for $this->moreThanOneVariantActive()->isVisible()->active()
      * useful to get query for products that:

--- a/src/models/search/ProductFinder.php
+++ b/src/models/search/ProductFinder.php
@@ -15,6 +15,7 @@ class ProductFinder extends Model
 {
     public $tagIds;
     public $q;
+    public $productId;
 
     public $defaultOrder = ['rank' => SORT_ASC];
 
@@ -39,7 +40,7 @@ class ProductFinder extends Model
     public function rules()
     {
         return [
-            [['tagIds'], 'integer', 'allowArray' => true],
+            [['tagIds', 'productId'], 'integer', 'allowArray' => true],
             [['q'], 'string'],
         ];
     }
@@ -80,6 +81,10 @@ class ProductFinder extends Model
 
         if (!empty($this->q)) {
             $this->query->fullTextSearch($this->q);
+        }
+
+        if (!empty($this->productId)) {
+            $this->query->productIdFilter($this->productId);
         }
 
         return $dataProvider;


### PR DESCRIPTION
This PR adds an optional productId filter to the ProductFinder search model which can be used e.g. for product-watchlists