### PR TITLE
fix multi move orders route

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,7 @@ return [
             'ignoreLanguageUrlPatterns' => [
                 '#^shop/shopping-cart/check-discount-code#' => '#^shop/shopping-cart/check-discount-code#',
                 '#^shop/dashboard/update-shipping-link#' => '#^shop/dashboard/update-shipping-link#',
-                '#^shop/data/add-tag-to-filter#' => '#^shop/data/add-tag-to-filter#',
-                '#^shop/data/add-tag-to-product#' => '#^shop/data/add-tag-to-product#',
-                '#^shop/data/sort-filter-tags#' => '#^shop/data/sort-filter-tags#',
-                '#^shop/data/sort-products#' => '#^shop/data/sort-products#',
-                '#^shop/data/sort-filters#' => '#^shop/data/sort-filters#',
-                '#^shop/data/sort-variants#' => '#^shop/data/sort-variants#',
-                '#^shop/data/update-email-template#' => '#^shop/data/update-email-template#',
-                '#^shop/data/update-email-template-context-menu#' => '#^shop/data/update-email-template-context-menu#',
-                '#^shop/data/load-template#' => '#^shop/data/load-template#',
+                '#^shop/dashboard/data/#' => '#^shop/dashboard/data/#',
             ]
         ]
     ],

--- a/src/views/dashboard/orders/index.php
+++ b/src/views/dashboard/orders/index.php
@@ -62,7 +62,7 @@ $(function() {
       var selectedOrders = $('.checkbox-select-single:checked').toArray().map(function(el) {
         return $(el).val();
       });
-      $.post('/shop/data/multi-move', {orders: selectedOrders, direction: $(this).data('move')},function(response) {
+      $.post('/shop/dashboard/data/multi-move', {orders: selectedOrders, direction: $(this).data('move')},function(response) {
         if (response.success) {
             location.reload();
         }


### PR DESCRIPTION


This PR fix the data/multi-move url in orders view.
The controller was moved to the dashboard subfolder, so the route for the ajax call has to be changed.
See: https://github.com/eluhr/yii2-shop-module/commit/d2451cc761d1ceee7aba2a1a11794656318baed0

Beside this fix, the ignoreLanguageUrlPatterns in the app config must be changed to, and as far as i can see, we could add an ignore for all actions from the dashboard/data controller - Updated the README.